### PR TITLE
PLANET-5377 Generate Json translation files from .po files

### DIFF
--- a/localscripts/commit_languages.sh
+++ b/localscripts/commit_languages.sh
@@ -94,6 +94,10 @@ rm -f translations/planet4-plugin-gutenberg-blocks/languages/*.po~
 rm -f translations/planet4-plugin-gutenberg-blocks/languages/enform/*.po~
 
 echo ""
+sh ./tmp/workspace/src/localscripts/generate-po2json.sh
+echo ""
+
+echo ""
 echo "Lets copy the modified languages file to the repository"
 echo ""
 cp translations/planet4-plugin-gutenberg-blocks/languages/ gitrepos/planet4-plugin-gutenberg-blocks/ -r

--- a/localscripts/generate-po2json.sh
+++ b/localscripts/generate-po2json.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+[ -x "$(command -v npm)" ] || { >&2 echo "npm is required but not installed, exiting."; exit 1; }
+
+echo ""
+echo "Installing po2json..."
+echo ""
+npm install po2json
+
+echo ""
+echo "Generating .po to .json files..."
+echo ""
+
+pofilenames=$(ls ./translations/planet4-plugin-gutenberg-blocks/languages/*.po)
+for pofilename in $pofilenames
+do
+   text_domain='planet4-blocks-backend'
+   if [[ "$pofilename" =~ .*"$text_domain".* ]]; then
+     suffix='script'
+   else
+     suffix='frontend'
+   fi
+   # Generate json file from .po file. (Note: The o/p filename should be ${domain}-${locale}-${handle}.json)
+   npx po2json "$pofilename" "${pofilename/.po/}-planet4-blocks-${suffix}.json" -f jed1.x;
+done
+
+echo ""
+echo "Json file generation done."
+echo ""


### PR DESCRIPTION
Ref. [PLANET-5377](https://jira.greenpeace.org/browse/PLANET-5377)

### Overview
- The WP documentation about [Javascript i18n support](https://make.wordpress.org/core/2018/11/09/new-javascript-i18n-support-in-wordpress/)
- The native way of json file generation is `wp i18n make-json` using [wp cli cmd](https://developer.wordpress.org/cli/commands/i18n/make-json/)
- The above command extract JavaScript strings from PO files and add them to individual JSON files

### Whats wrong with multiple json file?
- The WP offers `wp_set_script_translations()` function which accepts an optional third path argument that allows us to tell WordPress to first look in our plugin language folder for json translation files.

`wp_set_script_translations( 'my-handle', 'my-domain', plugin_dir_path( MY_PLUGIN ) . 'languages' );`

As the `wp i18n make-json` command generates a multiple json files, its difficult to link with above function.
Also the generated json files have an md5 hash appended to them and expected json file format in above function is `${domain}-${locale}-${handle}.json`

The documentation says -
> Alternatively it will also first check the given path for the md5 filename before defaulting to the WordPress languages directory.

But It wont works for me 🤷‍♂️ 

### Alternative ways to generate json file using [po2json](https://github.com/mikeedwards/po2json)
`po2json translation.po translation.json -f jed`

The po2json cli tool offer a simple command which produce a single json file per .po file. Considering multiple languages per NRO's its good to have one json file per language instead of multiple json files. also its easy to generate file format `${domain}-${locale}-${handle}.json` at the time to json file generation.

[Similar issue found on stackoverflow suggesting po2json option.](https://wordpress.stackexchange.com/questions/366881/how-should-you-internationalize-javascript-spread-in-multiple-files-but-build-in)

### Does Loco translate plugin offers JSON translation file format?
The [Loco translate does not officially support](https://localise.biz/wordpress/plugin/authors#:~:text=JavaScript,support%20for%20extracting%20strings%20from%20.) to generate json translation files, but can extracting translation strings from .js files.
We use loco plugin to extract the js strings & use po2Json for Json file.

### If we are Ok with above, Let's talk about P4 integration 🤔 
We have a [commit-translated-files](https://github.com/greenpeace/planet4-handbook/blob/develop/.circleci/config.yml#L296) CI job which commits language translation files from handbook to respective github repo's([blocks repo](https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/tree/master/languages) & [master theme](https://github.com/greenpeace/planet4-master-theme/tree/master/languages)) language folder on every time when editor click save button in Loco translate interface.

For me the good place to add json file generation logic is [commit_languages.sh](https://github.com/greenpeace/planet4-handbook/blob/planet-5377-json-translation/localscripts/commit_languages.sh#L97) file.

I also thought about the github action in blocks repo which executes on every language sync commit, but that way we need 2 commits one for language file sync and other for json files.

`Disclaimer: I have limited skills in bash scripting, so bear with me 🤖  `






