### PR TITLE
PLANET-6312: Fix scenarios and temporary disable visual comparison

### DIFF
--- a/.circleci/artifacts.yml
+++ b/.circleci/artifacts.yml
@@ -7,7 +7,7 @@ job_environments:
   develop_environment: &develop_environment
     APP_ENVIRONMENT: development
     APP_HOSTNAME: planet4-dev.greenpeace.org
-    APP_HOSTPATH:
+    APP_HOSTPATH: handbook
     CLOUDSQL_INSTANCE: p4-develop-k8s
     GCLOUD_CLUSTER: p4-development
     GOOGLE_PROJECT_ID: planet-4-151612
@@ -19,7 +19,7 @@ job_environments:
   release_environment: &release_environment
     APP_ENVIRONMENT: staging
     APP_HOSTNAME: planet4-stage.greenpeace.org
-    APP_HOSTPATH:
+    APP_HOSTPATH: handbook
     CLOUDSQL_INSTANCE: planet4-prod
     GCLOUD_CLUSTER: planet4-production
     GOOGLE_PROJECT_ID: planet4-production
@@ -30,7 +30,7 @@ job_environments:
     WP_STATELESS_BUCKET: planet4-handbook-stateless-release
   production_environment: &production_environment
     APP_HOSTNAME: planet4.greenpeace.org
-    APP_HOSTPATH:
+    APP_HOSTPATH: handbook
     CLOUDSQL_INSTANCE: planet4-prod
     GCLOUD_CLUSTER: planet4-production
     GOOGLE_PROJECT_ID: planet4-production

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ job_environments:
   develop_environment: &develop_environment
     APP_ENVIRONMENT: development
     APP_HOSTNAME: planet4-dev.greenpeace.org
-    APP_HOSTPATH:
+    APP_HOSTPATH: handbook
     CLOUDSQL_INSTANCE: p4-develop-k8s
     GCLOUD_CLUSTER: p4-development
     GOOGLE_PROJECT_ID: planet-4-151612
@@ -42,7 +42,7 @@ job_environments:
   release_environment: &release_environment
     APP_ENVIRONMENT: staging
     APP_HOSTNAME: planet4-stage.greenpeace.org
-    APP_HOSTPATH:
+    APP_HOSTPATH: handbook
     CLOUDSQL_INSTANCE: planet4-prod
     GCLOUD_CLUSTER: planet4-production
     GOOGLE_PROJECT_ID: planet4-production
@@ -53,7 +53,7 @@ job_environments:
     WP_STATELESS_BUCKET: planet4-handbook-stateless-release
   production_environment: &production_environment
     APP_HOSTNAME: planet4.greenpeace.org
-    APP_HOSTPATH:
+    APP_HOSTPATH: handbook
     CLOUDSQL_INSTANCE: planet4-prod
     GCLOUD_CLUSTER: planet4-production
     GOOGLE_PROJECT_ID: planet4-production

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -490,20 +490,13 @@ workflow_definitions:
 workflows:
   develop:
     jobs:
-      - visualtests-reference-develop:
-          <<: *on_develop_commit
       - build-develop:
           <<: *on_develop_commit
       - deploy-develop:
           <<: *on_develop_commit
           requires:
             - build-develop
-            - visualtests-reference-develop
       - test-develop:
-          <<: *on_develop_commit
-          requires:
-            - deploy-develop
-      - visualtests-compare-develop:
           <<: *on_develop_commit
           requires:
             - deploy-develop
@@ -511,22 +504,14 @@ workflows:
   production:
     unless: << pipeline.parameters.rollback >>
     jobs:
-      - visualtests-reference:
-          <<: *on_release_tag
       - build:
           <<: *on_release_tag
       - deploy-staging:
           <<: *on_release_tag
           requires:
             - build
-            - visualtests-reference
       - test-staging:
           <<: *on_release_tag
-          requires:
-            - deploy-staging
-      - visualtests-compare:
-          <<: *on_release_tag
-          notify: true
           requires:
             - deploy-staging
       - rollback-staging:

--- a/backstop-pages.json
+++ b/backstop-pages.json
@@ -1,0 +1,9 @@
+{
+  "scenarios": [
+    {
+      "label": "Planet4 product page",
+      "url": "https://APP_HOSTNAME/",
+      "delay": 2500
+    }
+  ]
+}


### PR DESCRIPTION
## Fix scenarios

Handbook is a path in the planet4.greenpeace.org domain, so we should keeps tests on this path.
Also adding a test for the root domain itself which is the Planet4 product page. (scenarios are merged with our [backstop defaults](https://github.com/greenpeace/planet4-backstop/blob/811a91a9a105682bfda3437e9d05bc15e7acebec/backstop.json#L32))

## Disable visual comparisons

[Deployment fails](https://app.circleci.com/pipelines/github/greenpeace/planet4-handbook/2315/workflows/6f8988f7-65dc-4b49-ba67-83564162a0b5/jobs/4847) because visual comparison can't be done on domains that have not been deployed yet.
We need to deploy first to then re-enable those tests.