### PR TITLE
PLANET-6312: Remove host path for deployment

### DIFF
--- a/.circleci/artifacts.yml
+++ b/.circleci/artifacts.yml
@@ -7,7 +7,7 @@ job_environments:
   develop_environment: &develop_environment
     APP_ENVIRONMENT: development
     APP_HOSTNAME: planet4-dev.greenpeace.org
-    APP_HOSTPATH: handbook
+    APP_HOSTPATH:
     CLOUDSQL_INSTANCE: p4-develop-k8s
     GCLOUD_CLUSTER: p4-development
     GOOGLE_PROJECT_ID: planet-4-151612
@@ -19,7 +19,7 @@ job_environments:
   release_environment: &release_environment
     APP_ENVIRONMENT: staging
     APP_HOSTNAME: planet4-stage.greenpeace.org
-    APP_HOSTPATH: handbook
+    APP_HOSTPATH:
     CLOUDSQL_INSTANCE: planet4-prod
     GCLOUD_CLUSTER: planet4-production
     GOOGLE_PROJECT_ID: planet4-production
@@ -30,7 +30,7 @@ job_environments:
     WP_STATELESS_BUCKET: planet4-handbook-stateless-release
   production_environment: &production_environment
     APP_HOSTNAME: planet4.greenpeace.org
-    APP_HOSTPATH: handbook
+    APP_HOSTPATH:
     CLOUDSQL_INSTANCE: planet4-prod
     GCLOUD_CLUSTER: planet4-production
     GOOGLE_PROJECT_ID: planet4-production

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ job_environments:
   develop_environment: &develop_environment
     APP_ENVIRONMENT: development
     APP_HOSTNAME: planet4-dev.greenpeace.org
-    APP_HOSTPATH: handbook
+    APP_HOSTPATH:
     CLOUDSQL_INSTANCE: p4-develop-k8s
     GCLOUD_CLUSTER: p4-development
     GOOGLE_PROJECT_ID: planet-4-151612
@@ -42,7 +42,7 @@ job_environments:
   release_environment: &release_environment
     APP_ENVIRONMENT: staging
     APP_HOSTNAME: planet4-stage.greenpeace.org
-    APP_HOSTPATH: handbook
+    APP_HOSTPATH:
     CLOUDSQL_INSTANCE: planet4-prod
     GCLOUD_CLUSTER: planet4-production
     GOOGLE_PROJECT_ID: planet4-production
@@ -53,7 +53,7 @@ job_environments:
     WP_STATELESS_BUCKET: planet4-handbook-stateless-release
   production_environment: &production_environment
     APP_HOSTNAME: planet4.greenpeace.org
-    APP_HOSTPATH: handbook
+    APP_HOSTPATH:
     CLOUDSQL_INSTANCE: planet4-prod
     GCLOUD_CLUSTER: planet4-production
     GOOGLE_PROJECT_ID: planet4-production


### PR DESCRIPTION
Handbook is still located on /handbook path, but the full site is deployed on the root path; 
removing the hostpath should fix the deployment process (which is currently broken a bit :grimacing: ).
An empty APP_HOSTPATH is what's currently used for production deployment.
(and then I'll fix the visual comparison the other way, by running custom tests on /handbook :hammer_and_wrench: )