### PR TITLE
PLANET-6312: Backstop tests on handbook path

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -490,13 +490,20 @@ workflow_definitions:
 workflows:
   develop:
     jobs:
+      - visualtests-reference-develop:
+          <<: *on_develop_commit
       - build-develop:
           <<: *on_develop_commit
       - deploy-develop:
           <<: *on_develop_commit
           requires:
             - build-develop
+            - visualtests-reference-develop
       - test-develop:
+          <<: *on_develop_commit
+          requires:
+            - deploy-develop
+      - visualtests-compare-develop:
           <<: *on_develop_commit
           requires:
             - deploy-develop
@@ -504,14 +511,22 @@ workflows:
   production:
     unless: << pipeline.parameters.rollback >>
     jobs:
+      - visualtests-reference:
+          <<: *on_release_tag
       - build:
           <<: *on_release_tag
       - deploy-staging:
           <<: *on_release_tag
           requires:
             - build
+            - visualtests-reference
       - test-staging:
           <<: *on_release_tag
+          requires:
+            - deploy-staging
+      - visualtests-compare:
+          <<: *on_release_tag
+          notify: true
           requires:
             - deploy-staging
       - rollback-staging:

--- a/backstop-pages.json
+++ b/backstop-pages.json
@@ -1,9 +1,25 @@
 {
   "scenarios": [
     {
-      "label": "Planet4 product page",
-      "url": "https://APP_HOSTNAME/",
-      "delay": 2500
+      "label": "Handbook homepage",
+      "url": "https://APP_HOSTNAME/handbook/",
+      "delay": 2500,
+      "misMatchThreshold": 1.5,
+      "selectors": [
+        "#header",
+        "#footer"
+      ]
+    },
+    {
+      "label": "Handbook search",
+      "url": "https://APP_HOSTNAME/handbook/?s=",
+      "delay": 3000,
+      "misMatchThreshold": 1.5,
+      "selectors": [
+        ".search-bar",
+        ".sort-filter",
+        "#filter-sidebar-options"
+      ]
     }
   ]
 }


### PR DESCRIPTION
APP_HOSTPATH value was emptied to allow deployment to the root of the planet4 subdomain (for dev and staging versions).
[Default backstop tests](https://github.com/greenpeace/planet4-backstop/blob/master/backstop.json) relied on this value to check the handbook; adding those tests with a fixed path will run backstop tests on the handbook again.

Re-adding visualcompare jobs to CI