### PR TITLE
PLANET-6982 Commit translated GF language files to Master theme

### DIFF
--- a/composer-local.json
+++ b/composer-local.json
@@ -17,8 +17,10 @@
   },
   "scripts": {
     "install:plugin-ideapush": "wp plugin install --activate https://storage.googleapis.com/planet4-3rdparty-plugins/ideapush-v8.14.zip",
+    "core:gf-language": "rsync -ar public/wp-content/themes/planet4-master-theme/languages/plugins/gravityforms/ public/wp-content/plugins/gravityforms/languages/",
     "site:custom": [
-      "@install:plugin-ideapush"
+      "@install:plugin-ideapush",
+      "@core:gf-language"
     ]
   }
 }

--- a/localscripts/commit_languages.sh
+++ b/localscripts/commit_languages.sh
@@ -38,10 +38,16 @@ echo " ########### Master Theme ####################"
 echo ""
 
 echo ""
-echo "Lets run the command to copy everything from the pod"
+echo "Lets run the command to copy Master Theme language files from the pod"
 echo ""
 
 kubectl -n "${HELM_NAMESPACE}" cp "$php://app/source/public/wp-content/themes/planet4-master-theme/languages" translations/planet4-master-theme/languages/
+
+echo ""
+echo "Lets run the command to copy GF plugin language files from the pod"
+echo ""
+
+kubectl -n "${HELM_NAMESPACE}" cp "$php://app/source/public/wp-content/plugins/gravityforms/languages" translations/planet4-master-theme/languages/plugins/gravityforms/
 
 echo ""
 echo "Lets clone the repository where we will send the translations to"


### PR DESCRIPTION
Ref. https://jira.greenpeace.org/browse/PLANET-6982

- The Loco translate plugin read and write translations into GF plugin language dir hence copy GF language files from Master theme to GF plugin's language dir
- On click of save button in Loco translate plugin, commit all translation(master-theme+GF) to Master-theme git repo

**Related PRs:**
https://github.com/greenpeace/planet4-base/pull/233
https://github.com/greenpeace/planet4-master-theme/pull/1879


**Testing :**
- To test the functionality (after approval of PR), we need to merge the PR and create a new tag (as like we created it  previously [lang.master12](https://github.com/greenpeace/planet4-handbook/releases/tag/lang.master12) for language file sync )
- Update the new tag into the [planet4-plugin-sync-lang-files](https://github.com/greenpeace/planet4-plugin-sync-lang-files/blob/master/sync-language-files.php#L102) plugin file
- Once the new tag files got picked into handbook instance, then goto Loco Translate >> Plugins >> [Gravity Forms](https://planet4.greenpeace.org/wp-admin/admin.php?bundle=gravityforms%2Fgravityforms.php&page=loco-plugin&action=view)
- It will show all the Gravity forms language translation files, here we can add new language , edit existing language translations and on click of "Save" button, the all translations changes will automatically get committed to [Master-theme](https://github.com/greenpeace/planet4-master-theme/tree/main/languages/plugins/gravityforms) repo.