### PR TITLE
PLANET-7731 Update Json file names as per handle names in master theme

### DIFF
--- a/localscripts/generate-master-theme-po2json.sh
+++ b/localscripts/generate-master-theme-po2json.sh
@@ -31,12 +31,12 @@ for pofilename in $pofilenames
 do
    text_domain='planet4-blocks-backend'
    if [[ "$pofilename" =~ .*"$text_domain".* ]]; then
-     suffix='editor-script'
+     suffix='theme-editor-script'
    else
-     suffix='script'
+     suffix='theme-script'
    fi
    # Generate json file from .po file. (Note: The o/p filename should be ${domain}-${locale}-${handle}.json)
-   npx po2json "$pofilename" "${pofilename/.po/}-master-theme-${suffix}.json" -f jed1.x;
+   npx po2json "$pofilename" "${pofilename/.po/}-planet4-blocks-${suffix}.json" -f jed1.x;
 done
 
 echo ""


### PR DESCRIPTION
Ref. https://jira.greenpeace.org/browse/PLANET-7731

Updated the language json files name of blocks plugin JS strings we per below structure -
`${domain}-${locale}-${handle}.json`

The `handle` value is defined in [ master theme](https://github.com/greenpeace/planet4-master-theme/blob/main/src/MasterBlocks.php#L121).