### PR TITLE
Configure a RAG services (Elasticsearch + Ollama) for testing a Swaya…

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -141,6 +141,14 @@ job_definitions:
       - run: BUILD_TAG=build-$(cat /tmp/workspace/var/circle-build-num) make deploy-helm
       - run: make post-deploy
       - run:
+          name: Deploy RAG services (Elasticsearch + Ollama) - develop only
+          command: |
+            if [ "${APP_ENVIRONMENT:-}" = "development" ]; then
+              /home/circleci/checkout/localscripts/deploy-rag-services.sh
+            else
+              echo "Skipping RAG services deploy (only runs in develop environment)"
+            fi
+      - run:
           name: Extract workflow from commit message
           command: |
             UNHOLD_WORKFLOW_LINE=$(git --git-dir=/home/circleci/checkout/.git log --format=%B -n 1 "$CIRCLE_SHA1" | { grep '^\/unhold ' || true; } )

--- a/k8s/elasticsearch-rag.yml
+++ b/k8s/elasticsearch-rag.yml
@@ -1,0 +1,68 @@
+---
+# PersistentVolumeClaim for RAG Elasticsearch data
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: elasticsearch-rag-data
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+---
+# Deployment for RAG Elasticsearch (separate from ElasticPress)
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: elasticsearch-rag
+  labels:
+    app: elasticsearch-rag
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: elasticsearch-rag
+  template:
+    metadata:
+      labels:
+        app: elasticsearch-rag
+    spec:
+      containers:
+        - name: elasticsearch
+          image: docker.elastic.co/elasticsearch/elasticsearch:9.3.0
+          env:
+            - name: discovery.type
+              value: single-node
+            - name: xpack.security.enabled
+              value: "false"
+            - name: ES_JAVA_OPTS
+              value: "-Xms512m -Xmx512m"
+          ports:
+            - containerPort: 9200
+          resources:
+            requests:
+              memory: "1Gi"
+              cpu: "500m"
+            limits:
+              memory: "2Gi"
+              cpu: "1"
+          volumeMounts:
+            - name: data
+              mountPath: /usr/share/elasticsearch/data
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: elasticsearch-rag-data
+---
+# Service to expose RAG Elasticsearch within the cluster
+apiVersion: v1
+kind: Service
+metadata:
+  name: elasticsearch-rag
+spec:
+  selector:
+    app: elasticsearch-rag
+  ports:
+    - port: 9200
+      targetPort: 9200

--- a/k8s/ollama.yml
+++ b/k8s/ollama.yml
@@ -1,0 +1,61 @@
+---
+# PersistentVolumeClaim for Ollama models
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: ollama-data
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 20Gi
+---
+# Deployment for Ollama (local LLM runtime)
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ollama
+  labels:
+    app: ollama
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ollama
+  template:
+    metadata:
+      labels:
+        app: ollama
+    spec:
+      containers:
+        - name: ollama
+          image: ollama/ollama:latest
+          ports:
+            - containerPort: 11434
+          resources:
+            requests:
+              memory: "4Gi"
+              cpu: "2"
+            limits:
+              memory: "8Gi"
+              cpu: "4"
+          volumeMounts:
+            - name: data
+              mountPath: /root/.ollama
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: ollama-data
+---
+# Service to expose Ollama within the cluster
+apiVersion: v1
+kind: Service
+metadata:
+  name: ollama
+spec:
+  selector:
+    app: ollama
+  ports:
+    - port: 11434
+      targetPort: 11434

--- a/localscripts/deploy-rag-services.sh
+++ b/localscripts/deploy-rag-services.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export GCLOUD_ZONE=${GCLOUD_ZONE:-us-central1-a}
+
+echo ""
+echo "Connecting to GKE cluster: ${GCLOUD_CLUSTER}"
+echo ""
+gcloud container clusters get-credentials "${GCLOUD_CLUSTER}" --zone "${GCLOUD_ZONE}" --project "${GOOGLE_PROJECT_ID}"
+
+echo ""
+echo "Deploying RAG services (Elasticsearch 9.x + Ollama) to namespace: ${HELM_NAMESPACE}"
+echo ""
+kubectl apply -f /home/circleci/checkout/k8s/ -n "${HELM_NAMESPACE}"
+
+echo ""
+echo "Waiting for Elasticsearch RAG to be ready..."
+echo ""
+kubectl rollout status deployment/elasticsearch-rag -n "${HELM_NAMESPACE}" --timeout=300s
+
+echo ""
+echo "Waiting for Ollama to be ready..."
+echo ""
+kubectl rollout status deployment/ollama -n "${HELM_NAMESPACE}" --timeout=300s
+
+echo ""
+echo "Pulling Llama 3.2 model into Ollama (this may take a few minutes on first run)..."
+echo ""
+kubectl exec -n "${HELM_NAMESPACE}" deployment/ollama -- ollama pull llama3.2:3b
+
+echo ""
+echo "Configuring RAG Chatbot WordPress plugin settings..."
+echo ""
+php=$(kubectl get pods --namespace "${HELM_NAMESPACE}" \
+  --sort-by=.metadata.creationTimestamp \
+  --field-selector=status.phase=Running \
+  -l "release=${HELM_RELEASE},component=php" \
+  -o jsonpath="{.items[-1:].metadata.name}")
+
+if [[ -z "$php" ]]; then
+  >&2 echo "ERROR: PHP pod not found in release ${HELM_RELEASE}"
+  exit 1
+fi
+
+echo "Found PHP pod: $php"
+
+kubectl exec -n "${HELM_NAMESPACE}" "$php" -- \
+  wp option patch update rag_chatbot_settings ollama_url "http://ollama:11434"
+
+kubectl exec -n "${HELM_NAMESPACE}" "$php" -- \
+  wp option patch update rag_chatbot_settings elasticsearch_url "http://elasticsearch-rag:9200"
+
+kubectl exec -n "${HELM_NAMESPACE}" "$php" -- \
+  wp plugin activate swayam-ai-chatbot
+
+echo ""
+echo "RAG Chatbot services deployed and configured successfully!"
+echo ""


### PR DESCRIPTION
…m AI Chatbot

### Add RAG Chatbot([swayam-ai-chatbot](https://github.com/sagarsdeshmukh/swayam-ai-chatbot)) infrastructure support (develop environment)

#### Summary :                                                                                                                                        
                                                                                                                                                 
This PR introduces the infrastructure needed to run the [Swayam AI Chatbot ](https://github.com/sagarsdeshmukh/swayam-ai-chatbot)(RAG-powered WordPress plugin) on the develop environment. It adds two new Kubernetes services — a dedicated Elasticsearch 9.x instance and Ollama (local LLM runtime) and wires them into the CI/CD deploy pipeline.

RAG services are currently gated to the development environment only. Staging and production are unaffected until explicitly enabled.

#### Changes :

**New:** [k8s/elasticsearch-rag.yml](https://github.com/greenpeace/planet4-handbook/blob/chatbot-testing-with-ollama-and-elasticsearch/k8s/elasticsearch-rag.yml)

- Deploys a dedicated Elasticsearch 9.3.0 instance for the RAG chatbot's vector search
- Completely separate from the existing ElasticPress Elasticsearch — no conflict
- Includes a PersistentVolumeClaim (10Gi) for data persistence across pod restarts
- ClusterIP service exposed internally as http://elasticsearch-rag:9200
- Memory-limited: 512m JVM heap, 2Gi container limit

**New:** [k8s/ollama.yml](https://github.com/greenpeace/planet4-handbook/blob/chatbot-testing-with-ollama-and-elasticsearch/k8s/ollama.yml)

- Deploys Ollama (ollama/ollama:latest) as the local LLM runtime for Llama 3.2
- Includes a PersistentVolumeClaim (20Gi) to cache the downloaded model across pod restarts
- ClusterIP service exposed internally as http://ollama:11434
- Resource limits: 4Gi–8Gi memory, 2–4 CPU cores

**New:** [localscripts/deploy-rag-services.sh](https://github.com/greenpeace/planet4-handbook/blob/chatbot-testing-with-ollama-and-elasticsearch/localscripts/deploy-rag-services.sh)

- Applies both k8s manifests to the correct $HELM_NAMESPACE
- Waits for both deployments to become ready (5-minute timeout each)
- Pulls the llama3.2:3b model into Ollama on first run (subsequent runs are fast — model is cached in the volume)
- Finds the running PHP pod and configures the plugin via WP-CLI:
  - Sets ollama_url => http://ollama:11434
  - Sets elasticsearch_url => http://elasticsearch-rag:9200
  - Activates the swayam-ai-chatbot plugin

**Modified:** [.circleci/config.yml
](https://github.com/greenpeace/planet4-handbook/blob/chatbot-testing-with-ollama-and-elasticsearch/.circleci/config.yml)
- Added a Deploy RAG services step in the shared deploy_steps block (after make post-deploy)
- Gated by APP_ENVIRONMENT check — only executes in development, silently skips for staging and production